### PR TITLE
fix: don't rotate blocks with a facing=up/down

### DIFF
--- a/src/main/java/net/hollowcube/schem/CoordinateUtil.java
+++ b/src/main/java/net/hollowcube/schem/CoordinateUtil.java
@@ -115,7 +115,8 @@ final class CoordinateUtil {
             case "north" -> "east";
             case "east" -> "south";
             case "south" -> "west";
-            default -> "north";
+            case "west" -> "north";
+            default -> in;
         };
     }
 


### PR DESCRIPTION
@mworzala is it ok for this to return null/empty string if the input is null/empty string? Or maybe other code was relying that this would output north to prevent some issues in that case. If so I'll need to change it to have cases for up/down instead of using the default to just return what was input.

The code currently forces north if a block is not facing north/east/south so if it is facing `up` or `down`, it will break its state.