### PR TITLE
BlockPaletteParser

### DIFF
--- a/src/main/java/net/hollowcube/schem/SchematicReader.java
+++ b/src/main/java/net/hollowcube/schem/SchematicReader.java
@@ -74,14 +74,7 @@ public final class SchematicReader {
         CompoundBinaryTag palette;
         byte[] blockArray;
         Integer paletteSize;
-        if (version == 1) {
-            palette = tag.getCompound("Palette");
-            Check.notNull(palette, "Missing required field 'Palette'");
-            blockArray = tag.getByteArray("BlockData");
-            Check.notNull(blockArray, "Missing required field 'BlockData'");
-            paletteSize = tag.getInt("PaletteMax");
-            Check.notNull(paletteSize, "Missing required field 'PaletteMax'");
-        } else {
+        if (version == 3) {
             var blockEntries = tag.getCompound("Blocks");
             Check.notNull(blockEntries, "Missing required field 'Blocks'");
 
@@ -90,6 +83,13 @@ public final class SchematicReader {
             blockArray = blockEntries.getByteArray("Data");
             Check.notNull(blockArray, "Missing required field 'Blocks.Data'");
             paletteSize = palette.size();
+        } else {
+            palette = tag.getCompound("Palette");
+            Check.notNull(palette, "Missing required field 'Palette'");
+            blockArray = tag.getByteArray("BlockData");
+            Check.notNull(blockArray, "Missing required field 'BlockData'");
+            paletteSize = tag.getInt("PaletteMax");
+            Check.notNull(paletteSize, "Missing required field 'PaletteMax'");
         }
 
         Block[] paletteBlocks = new Block[paletteSize];

--- a/src/main/java/net/hollowcube/schem/SchematicWriter.java
+++ b/src/main/java/net/hollowcube/schem/SchematicWriter.java
@@ -13,9 +13,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 
-public class SchematicWriter {
+public final class SchematicWriter {
 
-    public static byte @NotNull [] write(@NotNull Schematic schematic) {
+    public byte @NotNull [] write(@NotNull Schematic schematic) {
         CompoundBinaryTag.Builder schematicNBT = CompoundBinaryTag.builder();
         schematicNBT.putInt("Version", 2);
         schematicNBT.putInt("DataVersion", MinecraftServer.DATA_VERSION);
@@ -56,7 +56,7 @@ public class SchematicWriter {
         return out.toByteArray();
     }
 
-    public static void write(@NotNull Schematic schematic, @NotNull Path schemPath) throws IOException {
+    public void write(@NotNull Schematic schematic, @NotNull Path schemPath) throws IOException {
         Files.write(schemPath, write(schematic));
     }
 }

--- a/src/main/java/net/hollowcube/schem/blockpalette/BlockPaletteParser.java
+++ b/src/main/java/net/hollowcube/schem/blockpalette/BlockPaletteParser.java
@@ -1,0 +1,7 @@
+package net.hollowcube.schem.blockpalette;
+
+import net.minestom.server.instance.block.Block;
+
+public interface BlockPaletteParser {
+    Block parse(String key);
+}

--- a/src/main/java/net/hollowcube/schem/blockpalette/CommandBlockPaletteParser.java
+++ b/src/main/java/net/hollowcube/schem/blockpalette/CommandBlockPaletteParser.java
@@ -1,0 +1,11 @@
+package net.hollowcube.schem.blockpalette;
+
+import net.minestom.server.command.builder.arguments.minecraft.ArgumentBlockState;
+import net.minestom.server.instance.block.Block;
+
+public class CommandBlockPaletteParser implements BlockPaletteParser {
+    @Override
+    public Block parse(String key) {
+        return ArgumentBlockState.staticParse(key);
+    }
+}

--- a/src/test/java/net/hollowcube/schem/TestSchematicReaderRegressions.java
+++ b/src/test/java/net/hollowcube/schem/TestSchematicReaderRegressions.java
@@ -24,7 +24,7 @@ public class TestSchematicReaderRegressions {
     private @NotNull Schematic assertReadSchematic(@NotNull String path) {
         try (var is = getClass().getResourceAsStream(path)) {
             assertNotNull(is, "Failed to load resource: " + path);
-            return SchematicReader.read(is);
+            return new SchematicReader().read(is);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/src/test/java/net/hollowcube/schem/demo/DemoServer.java
+++ b/src/test/java/net/hollowcube/schem/demo/DemoServer.java
@@ -1,6 +1,7 @@
 package net.hollowcube.schem.demo;
 
 import net.hollowcube.schem.Rotation;
+import net.hollowcube.schem.SchematicReader;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.command.CommandSender;
 import net.minestom.server.command.builder.Command;
@@ -45,7 +46,7 @@ public class DemoServer {
                 var player = (Player) sender;
 
                 try (var is = getClass().getResourceAsStream("/" + String.join(" ", context.<String[]>get("path")) + ".schem")) {
-                    var schem = net.hollowcube.schem.SchematicReader.read(is);
+                    var schem = new SchematicReader().read(is);
                     schem.build(Rotation.NONE, false).apply(instance, player.getPosition(), () -> {
                         player.sendMessage("Done!");
                     });


### PR DESCRIPTION
I received a world which had a "minecraft:grass" in the palette.
To some extent it fits within the Schematic library to deal with its version upgrades.
This is the most naive way to do so.

Then I can use:
```
private static class SchemUpgradeParser implements BlockPaletteParser {
    @Override
    public Block parse(String key) {
        if (key.equals("minecraft:grass")) {
            return ArgumentBlockState.staticParse("minecraft:short_grass");
        }

        return ArgumentBlockState.staticParse(key);
    }
}
```