### PR TITLE
Support tile entities in schematic loading

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 metadata.format.version = "1.1"
 
 [versions]
-minestom = "1_20_5-323c75f8a5"
+minestom = "b0bad7e180"
 logback = "1.4.5" # For tests only
 
 nexuspublish = "1.3.0"

--- a/src/main/java/net/hollowcube/schem/BlockEntity.java
+++ b/src/main/java/net/hollowcube/schem/BlockEntity.java
@@ -1,0 +1,25 @@
+package net.hollowcube.schem;
+
+import net.kyori.adventure.nbt.CompoundBinaryTag;
+import net.minestom.server.coordinate.Point;
+import net.minestom.server.coordinate.Vec;
+
+public record BlockEntity(String id, Point point, CompoundBinaryTag trimmedTag) {
+
+    public static BlockEntity fromV3(CompoundBinaryTag blockTag) {
+        int[] position = blockTag.getIntArray("Pos");
+        return new BlockEntity(blockTag.getString("Id"), new Vec(position[0], position[1], position[2]), blockTag.getCompound("Data"));
+    }
+
+    public static BlockEntity fromV1(CompoundBinaryTag entityCompound) {
+        int[] position = entityCompound.getIntArray("Pos");
+        String id = entityCompound.getString("Id");
+        CompoundBinaryTag stripped = CompoundBinaryTag
+                .builder()
+                .put(entityCompound)
+                .remove("Pos")
+                .remove("Id")
+                .remove("Extra").build();
+        return new BlockEntity(id, new Vec(position[0], position[1], position[2]), stripped);
+    }
+}

--- a/src/main/java/net/hollowcube/schem/CoordinateUtil.java
+++ b/src/main/java/net/hollowcube/schem/CoordinateUtil.java
@@ -120,4 +120,8 @@ final class CoordinateUtil {
         };
     }
 
+    public static String getCoordinateKey(int x, int y, int z) {
+        return x + "," + y + "," + z;
+    }
+
 }

--- a/src/main/java/net/hollowcube/schem/SchematicBuilder.java
+++ b/src/main/java/net/hollowcube/schem/SchematicBuilder.java
@@ -9,6 +9,7 @@ import net.minestom.server.utils.Utils;
 import org.jetbrains.annotations.NotNull;
 
 import java.nio.ByteBuffer;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -116,6 +117,6 @@ public class SchematicBuilder {
         var out = new byte[blockBytes.position()];
         blockBytes.flip().get(out);
 
-        return new Schematic(size, offset, palette, out);
+        return new Schematic(size, offset, palette, out, Collections.emptyMap());
     }
 }

--- a/src/main/java/net/hollowcube/schem/SchematicReader.java
+++ b/src/main/java/net/hollowcube/schem/SchematicReader.java
@@ -103,7 +103,6 @@ public final class SchematicReader {
             for (BinaryTag entities : blockEntities) {
                 if (entities instanceof CompoundBinaryTag entity) {
                     BlockEntity blockEntity = BlockEntity.fromV3(entity);
-                    System.out.println(blockEntity);
 
                     Point coordinate = blockEntity.point();
                     blockEntitiesMap.put(CoordinateUtil.getCoordinateKey(coordinate.blockX(), coordinate.blockY(), coordinate.blockZ()), blockEntity);
@@ -121,7 +120,6 @@ public final class SchematicReader {
             for (BinaryTag entity : blockEntities) {
                 if (entity instanceof CompoundBinaryTag entityCompound) {
                     BlockEntity blockEntity = BlockEntity.fromV1(entityCompound);
-                    System.out.println(blockEntity);
 
                     Point coordinate = blockEntity.point();
                     blockEntitiesMap.put(CoordinateUtil.getCoordinateKey(coordinate.blockX(), coordinate.blockY(), coordinate.blockZ()), blockEntity);
@@ -139,7 +137,6 @@ public final class SchematicReader {
             for (BinaryTag entity : blockEntities) {
                 if (entity instanceof CompoundBinaryTag entityCompound) {
                     BlockEntity blockEntity = BlockEntity.fromV1(entityCompound);
-                    System.out.println(blockEntity);
 
                     Point coordinate = blockEntity.point();
                     blockEntitiesMap.put(CoordinateUtil.getCoordinateKey(coordinate.blockX(), coordinate.blockY(), coordinate.blockZ()), blockEntity);


### PR DESCRIPTION
This should allow for tile entity loading for all schematic versions. I have only tested for v3, but have followed the specification [here](https://github.com/SpongePowered/Schematic-Specification/).

Im not sure of a good way to support generating schematics with tile entities, so I'm open for input.

Create BlockEntity record to support block entity format across versions

Apply Block data when applying rotations

Add empty block data when generating a new schematic, will be replaced

Add loading tile entity support for v1, v2, and v3 schematics