### PR TITLE
Support for BlockEntities data

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 metadata.format.version = "1.1"
 
 [versions]
-minestom = "1_20_5-323c75f8a5"
+minestom = "18d6e0c6d6"
 logback = "1.4.5" # For tests only
 
 nexuspublish = "1.3.0"

--- a/src/main/java/net/hollowcube/schem/BlockEntity.java
+++ b/src/main/java/net/hollowcube/schem/BlockEntity.java
@@ -1,0 +1,24 @@
+package net.hollowcube.schem;
+
+import net.kyori.adventure.nbt.CompoundBinaryTag;
+import net.minestom.server.coordinate.Vec;
+import net.minestom.server.instance.block.Block;
+
+public record BlockEntity(String id, Vec pos, CompoundBinaryTag data) {
+    public Block apply(Block block) {
+        return block.withNbt(data);
+    }
+
+    public static BlockEntity from(CompoundBinaryTag tag) {
+        int[] pos = tag.getIntArray("Pos");
+        int x = pos[0];
+        int y = pos[1];
+        int z = pos[2];
+
+        return new BlockEntity(
+                tag.getString("Id"),
+                new Vec(x, y, z),
+                tag.getCompound("Data")
+        );
+    }
+}

--- a/src/main/java/net/hollowcube/schem/SchematicBuilder.java
+++ b/src/main/java/net/hollowcube/schem/SchematicBuilder.java
@@ -9,6 +9,7 @@ import net.minestom.server.utils.Utils;
 import org.jetbrains.annotations.NotNull;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -64,6 +65,8 @@ public class SchematicBuilder {
             paletteMap.put(Block.AIR, 0);
         }
 
+        var blockEntities = new ArrayList<BlockEntity>();
+
         // Write each block to the output buffer
         // Initial buffer size assumes that we have a palette less than 127
         // so each block is one byte. If the palette is larger, we will resize
@@ -106,6 +109,11 @@ public class SchematicBuilder {
             }
 
             Utils.writeVarInt(blockBytes, blockId);
+
+            if (block.hasNbt()) {
+                var blockEntity = new BlockEntity(block.name(), blockPos, block.nbt());
+                blockEntities.add(blockEntity);
+            }
         }
 
         var palette = new Block[paletteMap.size()];
@@ -116,6 +124,6 @@ public class SchematicBuilder {
         var out = new byte[blockBytes.position()];
         blockBytes.flip().get(out);
 
-        return new Schematic(size, offset, palette, out);
+        return new Schematic(size, offset, palette, out, blockEntities.toArray(BlockEntity[]::new));
     }
 }


### PR DESCRIPTION
Adds support for [`BlockEntities`](<https://github.com/SpongePowered/Schematic-Specification/blob/master/versions/schematic-3.md#fields-3>) as specified by Sponge Schematic v3

Reading schematics has been tested, writing schematics has **not** been tested.