### PR TITLE
Add support for newer minestom version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 metadata.format.version = "1.1"
 
 [versions]
-minestom = "1_20_5-323c75f8a5"
+minestom = "ccea53ac44"
 logback = "1.4.5" # For tests only
 
 nexuspublish = "1.3.0"

--- a/src/main/java/net/hollowcube/schem/Schematic.java
+++ b/src/main/java/net/hollowcube/schem/Schematic.java
@@ -1,11 +1,11 @@
 package net.hollowcube.schem;
 
+import net.hollowcube.schem.utils.Utils;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Vec;
 import net.minestom.server.instance.batch.BatchOption;
 import net.minestom.server.instance.batch.RelativeBlockBatch;
 import net.minestom.server.instance.block.Block;
-import net.minestom.server.utils.Utils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/src/main/java/net/hollowcube/schem/SchematicBuilder.java
+++ b/src/main/java/net/hollowcube/schem/SchematicBuilder.java
@@ -2,10 +2,10 @@ package net.hollowcube.schem;
 
 import it.unimi.dsi.fastutil.objects.Object2IntArrayMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import net.hollowcube.schem.utils.Utils;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Vec;
 import net.minestom.server.instance.block.Block;
-import net.minestom.server.utils.Utils;
 import org.jetbrains.annotations.NotNull;
 
 import java.nio.ByteBuffer;

--- a/src/main/java/net/hollowcube/schem/utils/Utils.java
+++ b/src/main/java/net/hollowcube/schem/utils/Utils.java
@@ -1,0 +1,44 @@
+package net.hollowcube.schem.utils;
+
+import org.jetbrains.annotations.ApiStatus;
+
+import java.nio.ByteBuffer;
+
+// https://github.com/Minestom/Minestom/blob/ba55b05e141af5e59f9bd7583e020513f8934b50/src/main/java/net/minestom/server/utils/Utils.java
+@ApiStatus.Internal
+public final class Utils {
+
+	private Utils() {
+	}
+
+	public static void writeVarInt(ByteBuffer buf, int value) {
+		if ((value & (0xFFFFFFFF << 7)) == 0) {
+			buf.put((byte) value);
+		} else if ((value & (0xFFFFFFFF << 14)) == 0) {
+			buf.putShort((short) ((value & 0x7F | 0x80) << 8 | (value >>> 7)));
+		} else if ((value & (0xFFFFFFFF << 21)) == 0) {
+			buf.put((byte) (value & 0x7F | 0x80));
+			buf.put((byte) ((value >>> 7) & 0x7F | 0x80));
+			buf.put((byte) (value >>> 14));
+		} else if ((value & (0xFFFFFFFF << 28)) == 0) {
+			buf.putInt((value & 0x7F | 0x80) << 24 | (((value >>> 7) & 0x7F | 0x80) << 16)
+					| ((value >>> 14) & 0x7F | 0x80) << 8 | (value >>> 21));
+		} else {
+			buf.putInt((value & 0x7F | 0x80) << 24 | ((value >>> 7) & 0x7F | 0x80) << 16
+					| ((value >>> 14) & 0x7F | 0x80) << 8 | ((value >>> 21) & 0x7F | 0x80));
+			buf.put((byte) (value >>> 28));
+		}
+	}
+
+	public static int readVarInt(ByteBuffer buf) {
+		// https://github.com/jvm-profiling-tools/async-profiler/blob/a38a375dc62b31a8109f3af97366a307abb0fe6f/src/converter/one/jfr/JfrReader.java#L393
+		int result = 0;
+		for (int shift = 0; ; shift += 7) {
+			byte b = buf.get();
+			result |= (b & 0x7f) << shift;
+			if (b >= 0) {
+				return result;
+			}
+		}
+	}
+}


### PR DESCRIPTION
This change allows the schem library to work on newer minestom versions where `utils/Utils.java` has been removed