### PR TITLE
fix: update to Minestom 1.21.3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,6 @@ description = "Schematic reader and writer for Minestom"
 
 repositories {
     mavenCentral()
-    maven(url = "https://jitpack.io")
 }
 
 dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 metadata.format.version = "1.1"
 
 [versions]
-minestom = "1_20_5-323c75f8a5"
+minestom = "989ed1b517"
 logback = "1.4.5" # For tests only
 
 nexuspublish = "1.3.0"

--- a/src/main/java/net/hollowcube/schem/Schematic.java
+++ b/src/main/java/net/hollowcube/schem/Schematic.java
@@ -5,11 +5,10 @@ import net.minestom.server.coordinate.Vec;
 import net.minestom.server.instance.batch.BatchOption;
 import net.minestom.server.instance.batch.RelativeBlockBatch;
 import net.minestom.server.instance.block.Block;
-import net.minestom.server.utils.Utils;
+import net.minestom.server.network.NetworkBuffer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.BiConsumer;
@@ -18,7 +17,6 @@ import java.util.function.UnaryOperator;
 /**
  * Represents a schematic file which can be manipulated in the world.
  */
-@SuppressWarnings("UnstableApiUsage")
 public record Schematic(
         Point size,
         Point offset,
@@ -61,11 +59,11 @@ public record Schematic(
      * @param applicator The function to call for each block in the schematic.
      */
     public void apply(@NotNull Rotation rotation, @NotNull BiConsumer<Point, Block> applicator) {
-        var blocks = ByteBuffer.wrap(this.blocks);
+        var blocks = NetworkBuffer.wrap(this.blocks, 0, 0);
         for (int y = 0; y < size().y(); y++) {
             for (int z = 0; z < size().z(); z++) {
                 for (int x = 0; x < size().x(); x++) {
-                    var block = palette[Utils.readVarInt(blocks)];
+                    var block = palette[NetworkBuffer.VAR_INT.read(blocks)];
                     if (block == null) {
                         logger.log(System.Logger.Level.WARNING, "Missing palette entry at {0}, {1}, {2}", x, y, z);
                         block = Block.AIR;


### PR DESCRIPTION
Looks to me that NetworkBuffers have auto-resizing capabilities, so I removed schem's manual resizing.