### PR TITLE
fix: Use Key instead of old namespace id for block handler

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 metadata.format.version = "1.1"
 
 [versions]
-minestom = "2025.07.11-1.21.7"
+minestom = "2025.07.17-1.21.8"
 
 junit = "5.11.4"
 junit-platform = "1.10.0"

--- a/src/main/java/net/hollowcube/schem/BlockEntityData.java
+++ b/src/main/java/net/hollowcube/schem/BlockEntityData.java
@@ -1,11 +1,13 @@
 package net.hollowcube.schem;
 
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.nbt.CompoundBinaryTag;
 import net.minestom.server.coordinate.Point;
 import org.jetbrains.annotations.NotNull;
 
+
 public record BlockEntityData(
-        @NotNull String id,
+        @NotNull Key key,
         @NotNull Point position,
         @NotNull CompoundBinaryTag data
 ) {

--- a/src/main/java/net/hollowcube/schem/SpongeSchematic.java
+++ b/src/main/java/net/hollowcube/schem/SpongeSchematic.java
@@ -58,7 +58,7 @@ public record SpongeSchematic(
                     var block = blockPalette.get(reader.next());
                     var blockEntity = blockEntitiesByPos.get(blockIndex(size, x, y, z));
                     if (blockEntity != null) {
-                        block = block.withHandler(BLOCK_MANAGER.getHandlerOrDummy(blockEntity.id()))
+                        block = block.withHandler(BLOCK_MANAGER.getHandlerOrDummy(blockEntity.key().namespace()))
                                 .withNbt(blockEntity.data());
                     }
 

--- a/src/main/java/net/hollowcube/schem/builder/SizedSchematicBuilder.java
+++ b/src/main/java/net/hollowcube/schem/builder/SizedSchematicBuilder.java
@@ -13,6 +13,7 @@ import net.kyori.adventure.nbt.CompoundBinaryTag;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Vec;
 import net.minestom.server.instance.block.Block;
+import net.minestom.server.instance.block.BlockHandler;
 import net.minestom.server.network.NetworkBuffer;
 import org.jetbrains.annotations.NotNull;
 
@@ -61,7 +62,7 @@ final class SizedSchematicBuilder implements SchematicBuilder {
 
         var blockHandler = block.handler();
         if (blockHandler != null) {
-            var blockEntityId = blockHandler.getNamespaceId().asString();
+            var blockEntityId = blockHandler.getKey();
             var blockEntityData = Objects.requireNonNullElse(block.nbt(), CompoundBinaryTag.empty());
             blockEntities.put(blockIndex, new BlockEntityData(blockEntityId, relPos, blockEntityData));
         }

--- a/src/main/java/net/hollowcube/schem/builder/UnboundedSchematicBuilder.java
+++ b/src/main/java/net/hollowcube/schem/builder/UnboundedSchematicBuilder.java
@@ -120,7 +120,7 @@ public class UnboundedSchematicBuilder implements SchematicBuilder {
             // Write block entity
             var blockHandler = block.handler();
             if (blockHandler != null) {
-                var blockEntityId = blockHandler.getNamespaceId().asString();
+                var blockEntityId = blockHandler.getKey();
                 var blockEntityData = Objects.requireNonNullElse(block.nbt(), CompoundBinaryTag.empty());
                 blockEntities.put(blockIndex(size, x, y, z), new BlockEntityData(blockEntityId, new Vec(x, y, z), blockEntityData));
             }

--- a/src/main/java/net/hollowcube/schem/reader/MCEditSchematicReader.java
+++ b/src/main/java/net/hollowcube/schem/reader/MCEditSchematicReader.java
@@ -7,6 +7,7 @@ import net.hollowcube.schem.BlockEntityData;
 import net.hollowcube.schem.Schematic;
 import net.hollowcube.schem.SpongeSchematic;
 import net.hollowcube.schem.util.GameDataProvider;
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.nbt.BinaryTagIO;
 import net.kyori.adventure.nbt.BinaryTagTypes;
 import net.kyori.adventure.nbt.ByteArrayBinaryTag;
@@ -96,9 +97,9 @@ public class MCEditSchematicReader implements SchematicReader {
             var id = getRequired(base, "id", BinaryTagTypes.STRING).value();
             var pos = getRequiredVec3(base, "");
             var data = base.remove("id").remove("x").remove("y").remove("z");
-            blockEntities.put(blockIndex(size, pos), new BlockEntityData(id, pos,
+            blockEntities.put(blockIndex(size, pos), new BlockEntityData(Key.key(id), pos,
                     // Always try to upgrade since this is always a legacy format
-                    gameData.upgradeBlockEntity(GameDataProvider.DATA_VERSION_UNKNOWN, gameData.dataVersion(), id, data)));
+                    gameData.upgradeBlockEntity(GameDataProvider.DATA_VERSION_UNKNOWN, gameData.dataVersion(), Key.key(id), data)));
         }
 
         // === Entities ===

--- a/src/main/java/net/hollowcube/schem/reader/ReadHelpers.java
+++ b/src/main/java/net/hollowcube/schem/reader/ReadHelpers.java
@@ -40,7 +40,7 @@ final class ReadHelpers {
 
     public static @NotNull Block readBlockState(@NotNull CompoundBinaryTag tag) {
         var name = getRequired(tag, "Name", BinaryTagTypes.STRING).value();
-        var block = Block.fromNamespaceId(name);
+        var block = Block.fromKey(name);
         assertTrue(block != null, "unknown block: {0}", name);
 
         var propsTag = tag.getCompound("Properties");

--- a/src/main/java/net/hollowcube/schem/reader/SpongeSchematicReader.java
+++ b/src/main/java/net/hollowcube/schem/reader/SpongeSchematicReader.java
@@ -5,6 +5,7 @@ import net.hollowcube.schem.BlockEntityData;
 import net.hollowcube.schem.Schematic;
 import net.hollowcube.schem.SpongeSchematic;
 import net.hollowcube.schem.util.GameDataProvider;
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.nbt.*;
 import net.minestom.server.command.builder.arguments.minecraft.ArgumentBlockState;
 import net.minestom.server.command.builder.exception.ArgumentSyntaxException;
@@ -128,8 +129,8 @@ public class SpongeSchematicReader implements SchematicReader {
 
                 var blockEntityData = extracted.build();
                 if (dataVersion < dataVersionMax)
-                    blockEntityData = gameData.upgradeBlockEntity(dataVersion, dataVersionMax, id.value(), blockEntityData);
-                blockEntities.put(blockIndex(size, pos), new BlockEntityData(id.value(), pos, blockEntityData));
+                    blockEntityData = gameData.upgradeBlockEntity(dataVersion, dataVersionMax, Key.key(id.value()), blockEntityData);
+                blockEntities.put(blockIndex(size, pos), new BlockEntityData(Key.key(id.value()), pos, blockEntityData));
             }
         } else {
             var blocksContainer = root.getCompound("Blocks");
@@ -161,8 +162,8 @@ public class SpongeSchematicReader implements SchematicReader {
                 var pos = getRequiredPoint(blockEntity, "Pos");
                 var data = blockEntity.getCompound("Data");
                 if (dataVersion < gameData.dataVersion())
-                    data = gameData.upgradeBlockEntity(dataVersion, gameData.dataVersion(), id.value(), data);
-                blockEntities.put(blockIndex(size, pos), new BlockEntityData(id.value(), pos, data));
+                    data = gameData.upgradeBlockEntity(dataVersion, gameData.dataVersion(), Key.key(id.value()), data);
+                blockEntities.put(blockIndex(size, pos), new BlockEntityData(Key.key(id.value()), pos, data));
             }
         }
 

--- a/src/main/java/net/hollowcube/schem/reader/StructureReader.java
+++ b/src/main/java/net/hollowcube/schem/reader/StructureReader.java
@@ -3,6 +3,7 @@ package net.hollowcube.schem.reader;
 import net.hollowcube.schem.BlockEntityData;
 import net.hollowcube.schem.Schematic;
 import net.hollowcube.schem.Structure;
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.nbt.BinaryTagIO;
 import net.kyori.adventure.nbt.BinaryTagTypes;
 import net.kyori.adventure.nbt.CompoundBinaryTag;
@@ -74,7 +75,7 @@ public class StructureReader implements SchematicReader {
             BlockEntityData blockEntity = null;
             if (blockCompound.get("nbt") instanceof CompoundBinaryTag nbt) {
                 var id = getRequired(nbt, "id", BinaryTagTypes.STRING).value();
-                blockEntity = new BlockEntityData(id, pos, nbt.remove("id"));
+                blockEntity = new BlockEntityData(Key.key(id), pos, nbt.remove("id"));
             }
 
             blocks.add(new Structure.BlockInfo(pos, state, blockEntity));

--- a/src/main/java/net/hollowcube/schem/util/GameDataProvider.java
+++ b/src/main/java/net/hollowcube/schem/util/GameDataProvider.java
@@ -1,5 +1,6 @@
 package net.hollowcube.schem.util;
 
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.nbt.CompoundBinaryTag;
 import org.jetbrains.annotations.NotNull;
 
@@ -34,7 +35,7 @@ public interface GameDataProvider {
         return blockState;
     }
 
-    default @NotNull CompoundBinaryTag upgradeBlockEntity(int fromVersion, int toVersion, @NotNull String id, @NotNull CompoundBinaryTag data) {
+    default @NotNull CompoundBinaryTag upgradeBlockEntity(int fromVersion, int toVersion, @NotNull Key key, @NotNull CompoundBinaryTag data) {
         return data;
     }
 

--- a/src/main/java/net/hollowcube/schem/writer/SpongeSchematicWriter.java
+++ b/src/main/java/net/hollowcube/schem/writer/SpongeSchematicWriter.java
@@ -77,7 +77,7 @@ public class SpongeSchematicWriter implements SchematicWriter {
         for (var blockEntity : schematic.blockEntities()) {
             var pos = blockEntity.position();
             blockEntityList.add(CompoundBinaryTag.builder()
-                    .putString("Id", blockEntity.id())
+                    .putString("Id", blockEntity.key().value())
                     .putIntArray("Pos", new int[]{pos.blockX(), pos.blockY(), pos.blockZ()})
                     .put("Data", blockEntity.data())
                     .build());

--- a/src/main/java/net/hollowcube/schem/writer/StructureWriter.java
+++ b/src/main/java/net/hollowcube/schem/writer/StructureWriter.java
@@ -59,7 +59,7 @@ public class StructureWriter implements SchematicWriter {
             blockTag.putInt("state", block.paletteIndex());
             blockTag.putIntArray("pos", new int[]{block.pos().blockX(), block.pos().blockY(), block.pos().blockZ()});
             if (block.blockEntity() != null)
-                blockTag.put("nbt", block.blockEntity().data().putString("id", block.blockEntity().id()));
+                blockTag.put("nbt", block.blockEntity().data().putString("id", block.blockEntity().key().value()));
             blocks.add(blockTag.build());
         }
         root.put("blocks", blocks.build());


### PR DESCRIPTION
Not sure what happened but at some point the version was upgraded but none of the namespace changes were applied.